### PR TITLE
Release 1.2.0: iLIS interface score + positives-only slider calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.2.0 - 2026-06-15
+
+### Added
+- iLIS interface score (AFM-LIS; Kim et al., github.com/flyark/AFM-LIS): the geometric mean `iLIS = sqrt(LIS * cLIS)`, where `cLIS` is the LIS PAE transform averaged only over residue pairs in direct contact (CB-else-CA within `contact_thresh`, default 8 Å). Adds `Interface.clis()`/`ilis()` and emits `interface_cLIS` / `interface_iLIS` next to `interface_LIS` in the per-run CSV. Validated against the official AFM-LIS `lis.py` (agreement to 4 decimal places).
+
+### Changed
+- Percentile sliders and meta-score are now calibrated on **positive (interacting) benchmark pairs only** (3,878 AF2/AF3 positive rows) instead of the full decoy-padded population, so predictions are ranked against the distribution of real interfaces. Per-feature AUROC is unchanged (monotonic transform); production `interface_meta_score` AUROC on the balanced benchmark is 0.878. Use `scripts/freeze_metascore_quantiles.py --label-filter positive|negative|all` to reproduce the deciles (`all` reproduces the prior scale bit-for-bit).
+- Removed the black poly-line connecting per-group slider markers in the report; each metric still shows its percentile marker, and the Meta marker is recomputed from the current calibration so it stays consistent with the recalibrated sliders.
+
 ## 1.1.0 - 2026-06-03
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alphajudge"
-version = "1.1.0"
+version = "1.2.0"
 description = "Evaluate AlphaFold-predicted protein complexes using confidence metrics and interface biophysics."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps `alphajudge` to **1.2.0** and adds a CHANGELOG entry for the two functional commits already on main (`3f5ec10`, `45dc059`).

## What's in this release
- **iLIS interface score** (AFM-LIS; Kim et al.): `iLIS = sqrt(LIS * cLIS)`, where `cLIS` is the LIS PAE transform averaged only over residue pairs in direct contact. Emits `interface_cLIS` / `interface_iLIS` in the per-run CSV; validated against the official AFM-LIS `lis.py` to 4 decimals.
- **Positives-only calibration**: percentile sliders and meta-score are now calibrated on interacting (positive) benchmark pairs only, so predictions rank against the distribution of real interfaces. Per-feature AUROC unchanged (monotonic); production `interface_meta_score` AUROC = 0.878. The report slider poly-line is dropped.

## Validation
- Full test suite on this branch: **34 passed, 6 skipped** (`pytest -n auto --dist loadfile`, BLAS threads capped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)