### PR TITLE
Show contact probability in the interface report

### DIFF
--- a/src/alphajudge/report.py
+++ b/src/alphajudge/report.py
@@ -86,6 +86,7 @@ _BENCHMARK_TAG = "AlphaJudge interacting reference set (n=3,878 AF2/AF3 pairs)"
 _GRADIENT = np.tile(np.linspace(0.0, 1.0, 1024), (2, 1))
 
 _FEATURE_DISPLAY = {
+    "interface_contact_prob_top10_mean": "Contact probability",
     "interface_LIS": "Interface LIS",
     "interface_ipSAE": "Interface ipSAE",
     "interface_pDockQ2": "Interface pDockQ2",
@@ -116,6 +117,7 @@ _FEATURE_UNITS = {
 # AF-derived group; confidence_score and pDockQ/mpDockQ are global to the
 # complex and live in COMPLEX_LEVEL_FEATURES.
 _AF_DERIVED_FEATURES = (
+    "interface_contact_prob_top10_mean",
     "interface_LIS",
     "interface_ipSAE",
     "interface_pDockQ2",


### PR DESCRIPTION
The percentile panel listed every metascore feature except contact probability, so the score the benchmark recommends never reached the report a user actually reads.

Nothing was missing from the calibration: `interface_contact_prob_top10_mean` is already in `META_SCORE_FEATURES` and has frozen `BENCHMARK_QUANTILES`, so `_feature_view` computes its percentile correctly. Only `_AF_DERIVED_FEATURES` — the tuple that drives the panel rows — omitted it.

Two lines: added the feature first in the AF-derived group, plus a display label.

**Behaviour when the score is unavailable** (no distogram, no `contact_probs.json`): the row renders with an em dash and no percentile marker, and the meta score falls back to the mean over available features. Verified on a real prediction both ways.

`test/test_report.py` passes (4 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)