### PR TITLE
Release AlphaJudge 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## Unreleased
 
+## 1.4.0 - 2026-08-07
+
 ### Added
 - **Confident contact count (CCC).** Counts inter-chain residue pairs that are both in physical contact and confidently placed relative to one another (predicted aligned error below a cutoff, 4 Å by default). Introduced by Lambourne et al. as a screening statistic and reported there to beat the usual confidence scores at low false-positive rates — which our own benchmark reproduces on AlphaFold2, where CCC leads contact probability on early retrieval (normalised partial AUC over the first 1% of controls, 0.482 versus 0.430) while losing clearly on global AUROC (0.822 versus 0.862). On AlphaFold3 contact probability wins both. CCC is therefore a specialist score for screens whose priority is the first few candidates, not a replacement default.
 - `Interface.confident_contacts(...)` and the `Interface.ccc` convenience property, plus `alphajudge.confident_contacts` for the standalone pieces.
+- `interface_expected_contacts` is now written to the per-interface score table, completing the contact-probability output contract documented in 1.3.0.
 
 ### Changed
 - **The report's AlphaFold panel now shows one row per construction, not one per published score.** `interface_LIS` and `interface_pDockQ2` were dropped from the slider panel: with `interface_ipSAE` and `average_interface_pae` already there, five of the six rows were summaries of the same predicted-aligned-error matrix (ipSAE and LIS correlate at ρ ≈ 0.9 on the benchmark), so the panel implied more independent evidence than it carried. The panel is now contact probability (distogram), CCC (PAE gated by contact geometry), ipSAE (interface-restricted PAE), ipTM (AlphaFold's own global number) and average interface PAE (the raw error the others are built from). Both dropped scores are still computed and still written to the score table; only the report layout changed.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AlphaJudge parses AF2, AF3, and Boltz-2 outputs and summarizes per-model / per-i
 | --- | --- | --- |
 | **AlphaFold internal** | ipTM, pTM, iptm+ptm/confidence_score, avg interface PAE, avg interface pLDDT, contact probabilities | unified for AF2/AF3 where available |
 | **physical & geometric** | buried area, contact pairs, H-bonds, salt bridges, interface composition, shape complementarity | self-contained |
-| **derived scores** | pDockQ, pDockQ2, mpDockQ, ipSAE, LIS, cLIS, iLIS, interface score, contact-probability summaries | implemented here |
+| **derived scores** | pDockQ, pDockQ2, mpDockQ, ipSAE, LIS, cLIS, iLIS, confident contact count (CCC), interface score, contact-probability summaries | implemented here |
 
 Use cases: rank poses, sanity-check AF confidences, or export features for ML.
 
@@ -181,7 +181,7 @@ process_many(
 )
 ```
 
-Key outputs per interface include: `average_interface_pae`, `interface_average_plddt`, `interface_contact_pairs`, `interface_contact_prob_max`, `interface_contact_prob_top10_mean`, `interface_area`, `interface_hb`, `interface_sb`, `interface_sc`, `interface_solv_en`, `interface_ipSAE`, `interface_LIS`, `interface_cLIS`, `interface_iLIS`, `interface_pDockQ2`, and per-run `pDockQ/mpDockQ`.
+Key outputs per interface include: `average_interface_pae`, `interface_average_plddt`, `interface_contact_pairs`, `interface_contact_prob_source`, `interface_contact_prob_max`, `interface_contact_prob_top10_mean`, `interface_expected_contacts`, `interface_ccc`, `interface_area`, `interface_hb`, `interface_sb`, `interface_sc`, `interface_solv_en`, `interface_ipSAE`, `interface_LIS`, `interface_cLIS`, `interface_iLIS`, `interface_pDockQ2`, and per-run `pDockQ/mpDockQ`.
 
 ---
 
@@ -207,8 +207,8 @@ AlphaJudge writes `interfaces.csv` with one row per interface (and includes the 
 - **iptm_ptm, iptm, ptm, confidence_score**: unified AF confidences
 - **pDockQ/mpDockQ**: global dockQ-like score (mpDockQ if multimer; pDockQ if dimer)
 - **average_interface_pae, interface_average_plddt, interface_num_intf_residues**
-- **interface_contact_pairs, interface_score, interface_pDockQ2, interface_ipSAE, interface_LIS, interface_cLIS, interface_iLIS**
-- **interface_contact_prob_source, interface_contact_prob_max, interface_contact_prob_top10_mean**: AF3 native `contact_probs`, or AF2 distogram-derived contact probability when full result pickles retain the `distogram` key — the softmax mass in distance bins lying entirely below the 8 Å contact cutoff (`AF2_DISTOGRAM_CONTACT_CUTOFF`). The AF2 construction follows Humphreys et al., *Science* 374:eabm4805 (2021), who introduced summed sub-12 Å distogram mass as the ranking statistic for proteome-scale AlphaFold interaction screens; it remains in use in the RoseTTAFold2-PPI human interactome (Zhang et al., *Science* 390:eadt1630, 2025). Two conventions differ here: the cutoff is 8 Å rather than 12 Å (sweeping it from 4 to 20 Å on a four-organism benchmark puts peak discrimination at 6–8 Å for both AlphaFold versions), and the interface is summarised as the mean of the ten largest inter-chain values as well as the maximum (they rank pairs interchangeably, ρ = 0.997). On AlphaFold3 contact probability is the strongest single interface score we measured, ahead of ipSAE and LIS; on AlphaFold2, where it is reconstructed from the distogram rather than read from a native contact output, it is not better than ipSAE/LIS. If AF2 result pickles do not contain `distogram` (for example because AlphaPulldown removed it with `--remove_keys_from_pickles`), these columns are empty/NaN and AlphaJudge logs a warning.
+- **interface_contact_pairs, interface_ccc, interface_score, interface_pDockQ2, interface_ipSAE, interface_LIS, interface_cLIS, interface_iLIS**: CCC counts Interactome3D-defined inter-chain residue contacts whose chain1→chain2 PAE is strictly below 4 Å. Alternative geometry, direction and boundary conventions are available through `Interface.confident_contacts(...)`.
+- **interface_contact_prob_source, interface_contact_prob_max, interface_contact_prob_top10_mean, interface_expected_contacts**: AF3 native `contact_probs`, or AF2 distogram-derived contact probability when full result pickles retain the `distogram` key — the softmax mass in distance bins lying entirely below the 8 Å contact cutoff (`AF2_DISTOGRAM_CONTACT_CUTOFF`). `interface_expected_contacts` is the sum over all inter-chain residue-pair probabilities. The AF2 construction follows Humphreys et al., *Science* 374:eabm4805 (2021), who introduced summed sub-12 Å distogram mass as the ranking statistic for proteome-scale AlphaFold interaction screens; it remains in use in the RoseTTAFold2-PPI human interactome (Zhang et al., *Science* 390:eadt1630, 2025). Two conventions differ here: the cutoff is 8 Å rather than 12 Å (sweeping it from 4 to 20 Å on a four-organism benchmark puts peak discrimination at 6–8 Å for both AlphaFold versions), and the interface is summarised as the mean of the ten largest inter-chain values as well as the maximum (they rank pairs interchangeably, ρ = 0.997). On AlphaFold3 contact probability is the strongest single interface score we measured, ahead of ipSAE and LIS; on AlphaFold2, where it is reconstructed from the distogram rather than read from a native contact output, it is not better than ipSAE/LIS. If AF2 result pickles do not contain `distogram` (for example because AlphaPulldown removed it with `--remove_keys_from_pickles`), these columns are empty/NaN and AlphaJudge logs a warning.
 - **interface_hb, interface_sb, interface_sc, interface_area, interface_solv_en**
 
 Exact header is asserted in tests to be consistent across AF2 and AF3 runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alphajudge"
-version = "1.3.0"
+version = "1.4.0"
 description = "Evaluate AlphaFold-predicted protein complexes using confidence metrics and interface biophysics."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/alphajudge/interface.py
+++ b/src/alphajudge/interface.py
@@ -266,7 +266,7 @@ class Interface:
         return self.confident_contacts()
 
     @cached_property
-    def contact_probability_scores(self) -> tuple[float, float]:
+    def contact_probability_scores(self) -> tuple[float, float, float]:
         return summarize_contact_prob_block(self._contact_prob, self._idx1, self._idx2)
 
     @cached_property
@@ -276,6 +276,10 @@ class Interface:
     @cached_property
     def contact_prob_top10_mean(self) -> float:
         return self.contact_probability_scores[1]
+
+    @cached_property
+    def expected_contacts(self) -> float:
+        return self.contact_probability_scores[2]
 
     @property
     def polar(self) -> float:

--- a/src/alphajudge/runner.py
+++ b/src/alphajudge/runner.py
@@ -123,6 +123,7 @@ def process(
                     "interface_contact_prob_source": confidence.contact_prob_source or "",
                     "interface_contact_prob_max": iface.contact_prob_max,
                     "interface_contact_prob_top10_mean": iface.contact_prob_top10_mean,
+                    "interface_expected_contacts": iface.expected_contacts,
                     "interface_ccc": iface.ccc,
                     "interface_score": iface.score_complex,
                     "interface_pDockQ2": pd2,

--- a/test/test_parsers_and_runner.py
+++ b/test/test_parsers_and_runner.py
@@ -44,6 +44,8 @@ EXPECTED_OUTPUT_COLUMNS = {
     "interface_contact_prob_source",
     "interface_contact_prob_max",
     "interface_contact_prob_top10_mean",
+    "interface_expected_contacts",
+    "interface_ccc",
     "interface_score",
     "interface_pDockQ2",
     "interface_ipSAE",
@@ -405,7 +407,7 @@ def test_clis_ilis_math_is_deterministic():
 def test_contact_probability_scores_math_is_deterministic():
     """
     Contact-probability summaries are computed over all residue pairs between
-    the two chains: max and mean of the ten largest values.
+    the two chains: max, mean of the ten largest values, and their total sum.
     """
     from alphajudge.interface import Interface
 
@@ -423,6 +425,7 @@ def test_contact_probability_scores_math_is_deterministic():
 
     assert nearly_equal(iface.contact_prob_max, 0.8)
     assert nearly_equal(iface.contact_prob_top10_mean, 0.375)
+    assert nearly_equal(iface.expected_contacts, 1.5)
 
     missing = object.__new__(Interface)
     missing._idx1 = np.array([0, 1])
@@ -430,6 +433,7 @@ def test_contact_probability_scores_math_is_deterministic():
     missing._contact_prob = None
     assert math.isnan(missing.contact_prob_max)
     assert math.isnan(missing.contact_prob_top10_mean)
+    assert math.isnan(missing.expected_contacts)
 
 
 def test_af2_distogram_contact_probs_softmax_cutoff_is_deterministic(tmp_path: Path):
@@ -650,6 +654,7 @@ def test_af3_contact_probability_scores_match_raw_contact_probs(
     assert row["interface_contact_prob_source"] == "af3_contact_probs"
     assert nearly_equal(row["interface_contact_prob_max"], iface.contact_prob_max)
     assert nearly_equal(row["interface_contact_prob_top10_mean"], iface.contact_prob_top10_mean)
+    assert nearly_equal(row["interface_expected_contacts"], iface.expected_contacts)
 
 
 def test_af3_contact_probs_alignment_uses_token_res_ids_with_extra_tokens():


### PR DESCRIPTION
## Summary

- release the confident contact count (CCC) implementation and full-benchmark report calibration
- document CCC conventions and the updated one-row-per-construction report panel
- complete the contact-probability CSV contract by emitting `interface_expected_contacts`
- bump the package version to 1.4.0

## Verification

- 35 parser/runner/report tests passed in the existing environment; two subprocess tests exposed that its global CLI predates CCC
- the changed unit, AF3 integration, required-schema, and both subprocess paths pass in an isolated editable 1.4.0 environment (5 passed)
- full GitHub Actions matrix runs on this PR

After merge, this commit will be tagged as `1.4.0`, published as a GitHub release, and uploaded to PyPI.
