### PR TITLE
Release AlphaJudge 1.4.1: invalidate stale CSV caches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## Unreleased
 
+## 1.4.1 - 2026-08-07
+
+### Fixed
+- Cached per-run CSVs are now reused only when their headers contain the current required fields. Normal and summary runs automatically recompute 1.3.0 or pre-release caches missing `interface_ccc` or `interface_expected_contacts`, so the documented 1.4 output schema no longer depends on knowing to pass `--force_recompute`.
+- Corrected the 1.4.0 CCC early-retrieval numbers below, which accidentally retained the superseded 250-per-cell pilot values. On the completed full raw-model pass, AF2 directional CCC versus top-ten contact probability is 0.447 versus 0.408 normalized partial AUC over the first 1% of controls; the macro-AUROCs are 0.822 versus 0.863.
+
 ## 1.4.0 - 2026-08-07
 
 ### Added
-- **Confident contact count (CCC).** Counts inter-chain residue pairs that are both in physical contact and confidently placed relative to one another (predicted aligned error below a cutoff, 4 Å by default). Introduced by Lambourne et al. as a screening statistic and reported there to beat the usual confidence scores at low false-positive rates — which our own benchmark reproduces on AlphaFold2, where CCC leads contact probability on early retrieval (normalised partial AUC over the first 1% of controls, 0.482 versus 0.430) while losing clearly on global AUROC (0.822 versus 0.862). On AlphaFold3 contact probability wins both. CCC is therefore a specialist score for screens whose priority is the first few candidates, not a replacement default.
+- **Confident contact count (CCC).** Counts inter-chain residue pairs that are both in physical contact and confidently placed relative to one another (predicted aligned error below a cutoff, 4 Å by default). Introduced by Lambourne et al. as a screening statistic and reported there to beat the usual confidence scores at low false-positive rates — which our completed full raw-model benchmark reproduces on AlphaFold2, where CCC leads contact probability on early retrieval (normalised partial AUC over the first 1% of controls, 0.447 versus 0.408) while losing clearly on global macro-AUROC (0.822 versus 0.863). On AlphaFold3 contact probability wins both. CCC is therefore a specialist score for screens whose priority is the first few candidates, not a replacement default.
 - `Interface.confident_contacts(...)` and the `Interface.ccc` convenience property, plus `alphajudge.confident_contacts` for the standalone pieces.
 - `interface_expected_contacts` is now written to the per-interface score table, completing the contact-probability output contract documented in 1.3.0.
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ AlphaJudge writes `interfaces.csv` with one row per interface (and includes the 
 - **interface_hb, interface_sb, interface_sc, interface_area, interface_solv_en**
 
 Exact header is asserted in tests to be consistent across AF2 and AF3 runs.
+When a normal or summary run finds a cached per-run CSV from an older release that lacks current
+required fields, AlphaJudge recomputes that run automatically; `--force_recompute` remains
+available when values, rather than the schema, must be refreshed.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alphajudge"
-version = "1.4.0"
+version = "1.4.1"
 description = "Evaluate AlphaFold-predicted protein complexes using confidence metrics and interface biophysics."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"

--- a/src/alphajudge/runner.py
+++ b/src/alphajudge/runner.py
@@ -20,6 +20,11 @@ from .report import render_pae_png
 logger = logging.getLogger(__name__)
 
 
+# Cached per-run CSVs from older releases are safe to reuse only when they
+# contain every field introduced by the current output contract.
+_REQUIRED_CACHE_COLUMNS = frozenset({"interface_ccc", "interface_expected_contacts"})
+
+
 def _save_pae_heatmap(
     pae_matrix,
     out_file: Path,
@@ -233,6 +238,23 @@ def _read_csv_rows(path: Path) -> list[dict]:
         return list(csv.DictReader(f))
 
 
+def _read_reusable_csv(path: Path) -> list[dict] | None:
+    """Return cached rows only when the file satisfies the current schema."""
+    rows = _read_csv_rows(path)
+    if not rows:
+        logger.info(f"existing {path} is empty; recomputing")
+        return None
+
+    missing = sorted(_REQUIRED_CACHE_COLUMNS - set(rows[0]))
+    if missing:
+        logger.info(
+            f"existing {path} is missing required column(s) "
+            f"{', '.join(missing)}; recomputing"
+        )
+        return None
+    return rows
+
+
 def _process_one_run(
     d_str: str,
     contact_thresh: float,
@@ -264,25 +286,21 @@ def _process_one_run(
             r.setdefault("source_dir", source_dir)
         return rows
 
-    # When building a summary, prefer reusing precomputed interfaces.csv
-    if want_summary and existing_csv.exists() and not force_recompute:
+    # Reuse a precomputed CSV only if its header satisfies the current output
+    # contract. This prevents an upgrade from silently aggregating stale rows.
+    if existing_csv.exists() and not force_recompute:
         try:
-            rows = _read_csv_rows(existing_csv)
-            if rows:
-                logger.info(f"reused existing {existing_csv} for aggregation")
+            rows = _read_reusable_csv(existing_csv)
+            if rows is not None:
+                if want_summary:
+                    logger.info(f"reused existing {existing_csv} for aggregation")
+                else:
+                    logger.info(f"reused existing {existing_csv}; skipping recompute")
                 if write_per_run_report:
                     _safe_write_per_run_report(d, csv_name=per_run_csv_name)
-                return (d_str, _stamp(rows))
-            logger.info(f"existing {existing_csv} is empty; recomputing")
+                return (d_str, _stamp(rows) if want_summary else [])
         except Exception as e:
             logger.warning(f"could not reuse {existing_csv}; recomputing: {e}")
-
-    # If no summary requested but interfaces.csv exists, skip recompute
-    if not want_summary and existing_csv.exists() and not force_recompute:
-        logger.info(f"reused existing {existing_csv}; skipping recompute")
-        if write_per_run_report:
-            _safe_write_per_run_report(d, csv_name=per_run_csv_name)
-        return (d_str, [])
 
     out_path = process(
         d_str,

--- a/test/test_parsers_and_runner.py
+++ b/test/test_parsers_and_runner.py
@@ -866,6 +866,70 @@ def test_headers_include_expected_schema(tmp_path: Path, af2_dir_src: Path, af3_
 # process_many
 # -------------------------
 
+@pytest.mark.parametrize("summary_csv", [None, "summary.csv"])
+def test_process_one_run_recomputes_cache_missing_current_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, summary_csv: str | None
+):
+    from alphajudge.runner import _process_one_run
+
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    stale = run_dir / "interfaces.csv"
+    stale.write_text("jobs,interface\nold,A_B\n")
+    calls: list[str] = []
+
+    def fake_process(
+        directory: str,
+        *args: Any,
+        per_run_csv_name: str = "interfaces.csv",
+        **kwargs: Any,
+    ) -> Path:
+        calls.append(directory)
+        out = Path(directory) / per_run_csv_name
+        with out.open("w", newline="") as f:
+            writer = csv.DictWriter(
+                f,
+                fieldnames=[
+                    "jobs",
+                    "interface",
+                    "interface_ccc",
+                    "interface_expected_contacts",
+                ],
+            )
+            writer.writeheader()
+            writer.writerow(
+                {
+                    "jobs": "fresh",
+                    "interface": "A_B",
+                    "interface_ccc": 3,
+                    "interface_expected_contacts": 4.5,
+                }
+            )
+        return out
+
+    monkeypatch.setattr("alphajudge.runner.process", fake_process)
+    _, rows = _process_one_run(
+        str(run_dir),
+        8.0,
+        100.0,
+        "best",
+        summary_csv,
+        10.0,
+        False,
+        "interfaces.csv",
+        True,
+        True,
+    )
+
+    assert calls == [str(run_dir)]
+    fresh = read_csv_rows(stale)
+    assert fresh[0]["interface_expected_contacts"] == "4.5"
+    if summary_csv is None:
+        assert rows == []
+    else:
+        assert rows[0]["interface_expected_contacts"] == "4.5"
+
+
 def test_process_many_aggregates_rows(
     tmp_path: Path,
     af2_pos_sample_src: list[Path],


### PR DESCRIPTION
## Summary

- reject cached per-run CSVs that lack `interface_ccc` or `interface_expected_contacts`
- recompute stale caches automatically in both direct and summary workflows
- add regression coverage for both paths
- correct superseded pilot early-retrieval values in the 1.4 changelog
- bump the patch version to 1.4.1

## Verification

- targeted stale-cache and contact-probability tests: 3 passed
- full Python matrix and Docker test-stage build run on this PR

This addresses the automated review on PR #25 that identified schema-incomplete cache reuse.
