### PR TITLE
Trigger CI on published releases so versioned Docker tags get pushed

### DIFF
--- a/.github/workflows/github_actions.yml
+++ b/.github/workflows/github_actions.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "**" ]
   pull_request:
     branches: [ "**" ]
+  release:
+    types: [published]
 
 jobs:
   test:


### PR DESCRIPTION
The `docker` job has a **"Build and push :<tag> on release"** step gated on `github.event_name == 'release'`, but the workflow's `on:` block only listed `push` and `pull_request`. A workflow that is never triggered by a release event can never satisfy that condition, so the step has never run.

## Evidence

Across the last 100 workflow runs:

| event | runs |
| --- | --- |
| `push` | 69 |
| `pull_request` | 31 |
| `release` | **0** |

Meanwhile nine releases have been published (1.0.0 through 1.4.1). Docker Hub correspondingly carries a single tag — confirmed two ways:

- Hub API `/v2/repositories/kosinskilab/alphajudge/tags` → `count: 1`
- Registry v2 `/v2/kosinskilab/alphajudge/tags/list` → `["latest"]`

That one tag comes from the separate push-to-main step, which is why it exists and nothing else does.

## The fix

```yaml
on:
  push:
    branches: [ "**" ]
  pull_request:
    branches: [ "**" ]
  release:
    types: [published]
```

Adding the trigger is sufficient; no job conditions need changing:

- `test` has no `if:`, so it runs on release events and satisfies `needs: test`
- `docker`'s existing `if:` already admits `release`/`published`
- `coverage-pages` stays gated on push-to-main and correctly skips

On a published release the PR-only and push-to-main steps skip, and the release step pushes `<user>/alphajudge:<tag_name>`.

As a side effect this also clears the static-analysis warning on `github.event.release.tag_name`, which was flagged as an invalid context precisely because no `release` trigger was declared.

## Not retroactive

Images for the already-published 1.0.0–1.4.1 releases are not backfilled by this change; those would need a manual build/push or a re-published release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)