### PR TITLE
Release 1.4.2: reproducible image builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## 1.4.2 - 2026-08-10
+
+### Fixed
+- Publishing a release now pushes a versioned Docker image. The CI workflow's `on:` block listed only `push` and `pull_request`, so the release-tagged build step could never run and Docker Hub carried only `:latest`. Images for the earlier 0.3.0 through 1.4.1 releases have been backfilled; those were built in August 2026, so they pair the tagged source with a contemporary dependency stack rather than the original one.
+
+### Changed
+- The Docker image builds against a pinned base image digest and a `docker/constraints.txt` lock file, so rebuilding a released tag resolves the same dependency stack instead of whatever is current at build time.
+- Runtime dependencies gain upper bounds (`biopython<2`, `numpy<3`, `scipy<2`, `matplotlib<4`) to guard against future breaking majors. No lower bounds were added, as older versions are untested.
+
 ## 1.4.1 - 2026-08-07
 
 ### Fixed

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim AS test
+FROM python:3.11-slim@sha256:90744cff8f32887f075c47d747a173ff333e9e98801667af93c357fa9f5e28ff AS test
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
@@ -13,9 +13,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install package and test deps
 COPY pyproject.toml README.md /app/
+COPY docker/constraints.txt /app/docker/constraints.txt
 COPY src /app/src
 RUN pip install --upgrade pip \
-    && pip install . \
+    && pip install -c docker/constraints.txt . \
     && pip install pytest \
     && pip cache purge
 
@@ -27,7 +28,7 @@ COPY test_data /app/test_data
 RUN pytest -q
 
 
-FROM python:3.11-slim AS runtime
+FROM python:3.11-slim@sha256:90744cff8f32887f075c47d747a173ff333e9e98801667af93c357fa9f5e28ff AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
@@ -36,9 +37,10 @@ WORKDIR /app
 
 # Install only runtime deps and package
 COPY pyproject.toml README.md /app/
+COPY docker/constraints.txt /app/docker/constraints.txt
 COPY src /app/src
 RUN pip install --upgrade pip \
-    && pip install . \
+    && pip install -c docker/constraints.txt . \
     && pip cache purge
 
 # Sensible default; override in deployments

--- a/docker/constraints.txt
+++ b/docker/constraints.txt
@@ -1,0 +1,17 @@
+# Exact dependency versions for the Docker image, so a rebuild of a given tag
+# resolves the same stack. Library consumers are unaffected: pyproject.toml
+# keeps loose bounds and this file is applied only by the image build.
+# Regenerate with: pip list --format=freeze inside the runtime image.
+biopython==1.88
+contourpy==1.3.3
+cycler==0.12.1
+fonttools==4.63.0
+kiwisolver==1.5.0
+matplotlib==3.11.1
+numpy==2.4.6
+packaging==26.3
+pillow==12.3.0
+pyparsing==3.3.2
+python-dateutil==2.9.0.post0
+scipy==1.17.1
+six==1.17.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "alphajudge"
-version = "1.4.1"
+version = "1.4.2"
 description = "Evaluate AlphaFold-predicted protein complexes using confidence metrics and interface biophysics."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 dependencies = [
-    "biopython",
-    "numpy",
-    "scipy",
-    "matplotlib",
+    "biopython<2",
+    "numpy<3",
+    "scipy<2",
+    "matplotlib<4",
 ]
 license = { text = "MIT" }
 


### PR DESCRIPTION
Makes future release images reproducible, and cuts the first release that will exercise the `release:` trigger merged in #27.

## Why

Rebuilding a released tag previously resolved whatever dependency stack was current:

| Layer | Before | After |
| --- | --- | --- |
| Base image | `python:3.11-slim` (floating) | pinned by digest `sha256:90744cff…` |
| Python deps | `biopython`, `numpy`, `scipy`, `matplotlib` — unbounded | `docker/constraints.txt` lock, exact versions |

Backfilling the 0.3.0–1.4.1 images made this concrete: every one pairs its tagged source with an August 2026 dependency stack rather than the original. That is unavoidable retroactively, but it should not keep happening.

## What changed

- `docker/constraints.txt` records the exact resolved versions (numpy 2.4.6, scipy 1.17.1, biopython 1.88, matplotlib 3.11.1 and transitives), applied in **both** the test and runtime stages so what the tests validate is what ships.
- Base image pinned by digest in both stages.
- `pyproject.toml` gains **upper bounds only**: `biopython<2`, `numpy<3`, `scipy<2`, `matplotlib<4`.

## On not exact-pinning pyproject

Deliberate. `alphajudge` is installed alongside other scientific packages, so `==` constraints in a library's metadata cause resolver conflicts for consumers. Reproducibility belongs in the image, which is what the constraints file provides. Lower bounds are omitted because older versions are untested — asserting `numpy>=1.24` would be a guess. The caps guard against the next breaking major.

## Validation

The `docker` job builds the test stage on this PR, running `pytest` inside the image against the pinned stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)